### PR TITLE
Sentryの初期設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/global/*yml
 /public/packs
 /public/packs-test
 /node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'devise-i18n'
 gem 'foreman'
 gem 'active_model_serializers', '~> 0.10.0'
 
+# エラーキャッチ
+gem "sentry-raven"
+
 group :test do
   gem "database_cleaner", "~> 1.7.0"
   gem "factory_bot_rails", "~> 4.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     foreman (0.64.0)
       dotenv (~> 0.7.0)
@@ -107,6 +109,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     msgpack (1.2.4)
+    multipart-post (2.0.0)
     mysql2 (0.5.2)
     nio4r (2.3.1)
     nokogiri (1.8.4)
@@ -174,6 +177,8 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -221,6 +226,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 5.2.0)
   rspec-rails (~> 3.7)
+  sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,10 @@ module QiitaClone
       config.environment = Rails.env.to_s
       config.config_directory = Rails.root.join('config/global').to_s
     end
+
+    Raven.configure do |config|
+      config.dsn = Global.sentry.api_key
+      config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+    end
   end
 end

--- a/config/global/devise.yml.sample
+++ b/config/global/devise.yml.sample
@@ -1,0 +1,2 @@
+default:
+  :secret_key: ""

--- a/config/global/sentry.yml.sample
+++ b/config/global/sentry.yml.sample
@@ -1,0 +1,2 @@
+default:
+  :api_key: ""


### PR DESCRIPTION
## 概要

sentryを導入する

### 実装内容
- [ ] sentryのSDKを使うためにGemfileに追記
- [ ] sentryの環境設定を`config/application.rb`に導入
- [ ] sentryの環境変数をglobalで管理し、sampleファイルを作成(deviseもなかったので一緒に)

## 関連するIssue
#36 

## 参考サイト
https://docs.sentry.io/clients/ruby/integrations/rails/

