### PR TITLE
Gemfile.lockの修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,13 +118,13 @@ GEM
       rubocop (>= 0.53.0)
       rubocop-rspec (>= 1.24.0)
     orm_adapter (0.5.0)
-    pluginator (1.5.0)
-    pre-commit (0.38.1)
-      pluginator (~> 1.5)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
+    pluginator (1.5.0)
     powerpack (0.1.2)
+    pre-commit (0.38.1)
+      pluginator (~> 1.5)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -244,8 +244,8 @@ DEPENDENCIES
   global
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
-  pre-commit
   onkcop
+  pre-commit
   pry-byebug
   puma (~> 3.11)
   rack-cors


### PR DESCRIPTION
## 概要
developでbundle installした時に、Gemfile.lockに差分が出たので切り分け