### PR TITLE
[WIP]投稿ページの実装(フロントエンド)

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def create
-    @article = current_user.article.new(article_params)
+    @article = Article.new(article_params)
     if @article.save!
       render json: @article, serializer: ArticleSerializer, status: 200
     else

--- a/frontend/src/pages/CreateArticle/CreateArticle.vue
+++ b/frontend/src/pages/CreateArticle/CreateArticle.vue
@@ -1,16 +1,37 @@
 <template src='./createArticle.html'></template>
 <style lang='scss' src='./createArticle.scss' scoped></style>
 <script>
+import axios from 'axios'
 import marked from 'marked'
+
+const DOMAIN_BASE = process.env.DOMAIN_BASE
+
 export default {
   data () {
     return {
-      markdown: ''
+      markdown: '',
+      title: '',
+      body: '',
+      user_id: ''
     }
   },
   methods: {
     preview: function () {
       return marked(this.markdown)
+    },
+    postArticle: function () {
+      const params = {
+        article: {
+          title: this.title,
+          body: this.body,
+          user_id: this.user_id
+        }
+      }
+      axios.post(`${DOMAIN_BASE}/articles`, params)
+        .then(response => {
+          console.log(response.data)
+          console.log(response.status)
+        })
     }
   }
 }

--- a/frontend/src/pages/CreateArticle/createArticle.html
+++ b/frontend/src/pages/CreateArticle/createArticle.html
@@ -1,15 +1,29 @@
 <div class="createArticle ui segment">
   <h1>記事投稿ページ</h1>
-
-  <div class="ui grid">
-    <div class="eight wide column">
-      <h2>入力スペース</h2>
-    <textarea class="markdown ui segment" v-model="markdown" placeholder="本文を書いてみよう"></textarea>
+  <form v-on:submit.prevent="postArticle">
+    <div class="ui grid">
+      <div class="eight wide column">
+        <h2>入力スペース</h2>
+        <div class="one field">
+          <div class="field">
+            <label>タイトル</label>
+            <input type="text" name="title" v-model="title" class="ui segment" placeholder="タイトルを入力してください">
+          </div>
+          <div class="field">
+            <label>user_id</label>
+            <input type="text" name="title" v-model="user_id" class="ui segment" placeholder="user_idを入力してください">
+          </div>
+        </div>
+        <div v-model="markdown">
+          <label>本文</label>
+          <textarea class="markdown ui segment" v-model="body" placeholder="本文を書いてみよう"></textarea>
+        </div>
+      </div>
+      <div class="eight wide column">
+        <h2>プレビュー</h2>
+        <div class="preview" v-html="preview()"></div>
+      </div>
     </div>
-    <div class="eight wide column">
-      <h2>プレビュー</h2>
-      <div class="preview" v-html="preview()"></div>
-    </div>
-  </div>
-
+    <button class="ui button green" type="submit">投稿する</button>
+  </form>
 </div>


### PR DESCRIPTION
## 概要

投稿ページから作成した記事をAPI叩いてDBに登録する。

### 実装内容
- [ ] 投稿ボタンの追加
- [ ] createArticle.vueにAPIを叩いてpostする処理を追加

## 関連するIssue
#25 