### PR TITLE
timesメソッドのブロック引数を削除

### DIFF
--- a/db/fixtures/01_user.rb
+++ b/db/fixtures/01_user.rb
@@ -1,7 +1,7 @@
 require "faker"
 
 # seeds of User
-100.times do |user|
+100.times do
   first_name = Faker::Name.first_name
   last_name = Faker::Name.last_name
   email = Faker::Internet.email
@@ -13,5 +13,4 @@ require "faker"
     s.email = email
     s.password = password
   end
-  user # rubocopに怒られるので、timesメソッドのブロック引数を明示的に設置
 end

--- a/db/fixtures/02_article.rb
+++ b/db/fixtures/02_article.rb
@@ -2,7 +2,7 @@ require "faker"
 
 # seeds of Article
 
-100.times do |article|
+100.times do
   title = Faker::Markdown.headers
   body = Faker::Markdown.sandwich(5, 3)
 
@@ -11,5 +11,4 @@ require "faker"
     s.title = title
     s.user_id = rand(1..100)
   end
-  article # rubocopに怒られるので、timesメソッドのブロック引数を明示的に設置
 end


### PR DESCRIPTION
## 概要

seed-fuそれぞれに使用していたtimesメソッドのブロック引数が不要だったので、削除

## 実装内容

- [ ] b/fixtures/01_user.rbからブロック引数を削除
- [ ] b/fixtures/02_article.rbからブロック引数を削除