### PR TITLE
データ取得前のエラーに対処

### DIFF
--- a/frontend/src/pages/EditArticle/EditArticle.vue
+++ b/frontend/src/pages/EditArticle/EditArticle.vue
@@ -22,7 +22,9 @@ export default {
   methods: {
     preview: function () {
       /* sanitizeでタグをそのままescapeさせる */
-      return marked(this.article.body, {sanitize: true})
+      if (this.article.body) {
+        return marked(this.article.body, {sanitize: true})
+      }
     },
     putArticle: function () {
       const params = {


### PR DESCRIPTION
## Overview
 - `this.article.body` が `undefined` のとき、marked の第一引数に undefined を渡すことになり、エラーしていたので、修正。